### PR TITLE
validation logic for the .conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OBJ_CLIENT		=	$(addprefix ./$(OBJ_CLIENT_REP)/, $(SRC_CLIENT:.cpp=.o))
 OBJ_SERVER		=	$(addprefix ./$(OBJ_SERVER_REP)/, $(SRC_SERVER:.cpp=.o))
 
 CXX				=	g++
-FLAGS			=	-Wall -Werror -Wextra
+FLAGS			=	-Wall -Werror -Wextra -std=c++20
 RDLINE_FLAGS	=	-lreadline 
 HDR_FLAGS_D		=	-I daemon/
 HDR_FLAGS_C		=	-I client/

--- a/daemon/incs/parsing.hpp
+++ b/daemon/incs/parsing.hpp
@@ -12,21 +12,24 @@ class ProgramConfig {
 private : 
 
     std::string cmd;
-    int numprocs;
-    std::string umask;
+    int numprocs = -1;
+    std::string umask = "022";
     std::string workingdir;
-    bool autostart;
-    std::string autorestart;
+    bool autostart = false;
+    std::string autorestart = "unexpected";
     std::vector<int> exitcodes;
-    int startretries;
-    int starttime;
-    std::string stopsignal;
-    int stoptime;
-    std::string stdout_file;
-    std::string stderr_file;
+    int startretries = -1;
+    int starttime = -1;
+    std::string stopsignal = "TERM";
+    int stoptime = -1;
+    std::string stdout_file = "/dev/null";
+    std::string stderr_file = "/dev/null";
     std::map<std::string, std::string> env;
 
 public:
+
+
+
     // Getters
     std::string getCmd() const { return cmd; }
     int getNumprocs() const { return numprocs; }
@@ -85,7 +88,64 @@ public:
         }
     }
 
+bool isValid() {
+        bool valid = true;
+
+        if (cmd.empty()) {
+            std::cerr << "Erreur: command est obligatoire." << std::endl;
+            valid = false;
+        }
+        if (workingdir.empty()) {
+            std::cerr << "Erreur: workingdir est obligatoire." << std::endl;
+            valid = false;
+        }
+
+        if (numprocs == -1) {
+            std::cerr << "Avertissement: numprocs non défini, valeur par défaut = 1" << std::endl;
+            numprocs = 1;
+        } else if (numprocs <= 0) {
+            std::cerr << "Avertissement: numprocs invalide, valeur par défaut = 1" << std::endl;
+            numprocs = 1;
+        }
+
+        if (startretries == -1) {
+            std::cerr << "Avertissement: startretries non défini, valeur par défaut = 3" << std::endl;
+            startretries = 3;
+        } else if (startretries <= 0) {
+            std::cerr << "Avertissement: startretries invalide, valeur par défaut = 3" << std::endl;
+            startretries = 3;
+        }
+
+        if (starttime == -1) {
+            std::cerr << "Avertissement: starttime non défini, valeur par défaut = 1" << std::endl;
+            starttime = 1;
+        } else if (starttime <= 0) {
+            std::cerr << "Avertissement: starttime invalide, valeur par défaut = 1" << std::endl;
+            starttime = 1;
+        }
+
+        if (stoptime == -1) {
+            std::cerr << "Avertissement: stoptime non défini, valeur par défaut = 10" << std::endl;
+            stoptime = 10;
+        } else if (stoptime <= 0) {
+            std::cerr << "Avertissement: stoptime invalide, valeur par défaut = 10" << std::endl;
+            stoptime = 10;
+        }
+
+        if (exitcodes.empty()) {
+            std::cerr << "Avertissement: exitcodes non défini, valeur par défaut = {0, 2}" << std::endl;
+            exitcodes = {0, 2};
+        }
+
+        if (env.empty()) {
+            std::cerr << "Avertissement: Aucun environnement défini." << std::endl;
+        }
+
+        return valid;
+    }
 };
+
+
 
 void parsing(char **args);
 

--- a/daemon/parsing.cpp
+++ b/daemon/parsing.cpp
@@ -162,5 +162,20 @@ void parsing(char **args)
         return;
     }
     std::map<std::string, ProgramConfig> programs = parse_config(filename); 
+
+    for (auto it = programs.begin(); it != programs.end(); ) {
+    if (!it->second.isValid()) {
+        std::cerr << "Erreur: Configuration invalide pour le programme " << it->first << ". Il sera ignoré." << std::endl;
+        it = programs.erase(it);
+    } else {
+        ++it;
+    }
+}
+
+if (programs.empty()) {
+    std::cerr << "Aucun programme valide dans la configuration. Arrêt du programme." << std::endl;
+    exit(EXIT_FAILURE);
+}
+
     log_config(programs);   
 }


### PR DESCRIPTION
mandatory parameters cause error log if missing

We now set default values to parameters if we can do so.